### PR TITLE
upgraded runtime to nodejs14.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ $RECYCLE.BIN/
 
 
 # End of https://www.gitignore.io/api/osx,node,linux,windows
+
+.idea

--- a/template.yaml
+++ b/template.yaml
@@ -69,7 +69,7 @@ Resources:
     Properties:
       CodeUri: document_batch
       Handler: app.lambdaHandler
-      Runtime: nodejs8.10
+      Runtime: nodejs14.x
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           BUCKET_NAME: !Ref TargetBucket


### PR DESCRIPTION
Hi there,
The runtime parameter of `nodejs8.10` is no longer supported for creating or updating AWS Lambda functions.
